### PR TITLE
* fix warningBox not being initialized causing nullref excpetion in a…

### DIFF
--- a/Editor/CheckSystem/CheckResult.cs
+++ b/Editor/CheckSystem/CheckResult.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace ImmerzaSDK.Manager.Editor
 {
     public enum ResultType
@@ -12,5 +15,58 @@ namespace ImmerzaSDK.Manager.Editor
         public ResultType Type { get; set; }
         public string Message { get; set; }
         public UnityEngine.Object ContextObject { get; set; }
+    }
+
+    public class CheckContext
+    {
+        private List<CheckResult> _results = new List<CheckResult>();
+        private int _numWarnings = 0;
+        private int _numErrors = 0;
+
+        public IEnumerable<CheckResult> Results { get => _results; }
+        public bool HasWarnings { get => _numWarnings > 0; }
+        public bool HasErrors {  get => _numErrors > 0; }
+        public bool AllSucceeded {  get => !HasWarnings && !HasErrors; }
+
+        public void Reset()
+        {
+            _results.Clear();
+            _numWarnings = 0;
+            _numErrors = 0;
+        }
+
+        public void AddError(string message)
+        {
+            AddError(message, null);
+        }
+        public void AddError(string message, UnityEngine.Object contextObject)
+        {
+            AddResult(message, ResultType.Error, contextObject);
+        }
+        public void AddWarning(string message)
+        {
+            AddWarning(message, null);
+        }
+        public void AddWarning(string message, UnityEngine.Object contextObject)
+        {
+            AddResult(message, ResultType.Warning, contextObject);
+        }
+        public void AddSuccess(string message)
+        {
+            AddSuccess(message, null);
+        }
+        public void AddSuccess(string message, UnityEngine.Object contextObject)
+        {
+            AddResult(message, ResultType.Success, contextObject);
+        }
+        public void AddResult(string message, ResultType type, UnityEngine.Object contextObject)
+        {
+            switch (type)
+            {
+                case ResultType.Error:   ++_numErrors; break;
+                case ResultType.Warning: ++_numWarnings; break;
+            }
+            _results.Add(new CheckResult { Type = type, Message = message, ContextObject = contextObject });
+        }
     }
 }

--- a/Editor/CheckSystem/Checks/EndSceneCheck.cs
+++ b/Editor/CheckSystem/Checks/EndSceneCheck.cs
@@ -3,9 +3,10 @@ using ImmerzaSDK.Manager.Editor;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
+[CheckableAttribute(displayName: "LUA EndScene Check")]
 public class EndSceneChecker : ICheckable
 {
-    List<CheckResult> ICheckable.RunCheck()
+    public void RunCheck(CheckContext context)
     {
         List<LuaAsset> scripts = CheckUtil.GetLuaAssets();
 
@@ -15,27 +16,10 @@ public class EndSceneChecker : ICheckable
         {
             if (regex.IsMatch(script.content))
             {
-                return new List<CheckResult> 
-                {
-                    new()
-                    {
-                        Type = ResultType.Success,
-                        Message = "EndScene() check succeeded",
-                        ContextObject = null
-                    }
-                };
-
+                return;
             }
         }
 
-        return new List<CheckResult> 
-        {
-            new()
-            {
-                Type = ResultType.Error,
-                Message = "None of the Lua scripts call EndScene(), which is required before exporting.",
-                ContextObject = null
-            }
-        };
+        context.AddError("None of the Lua scripts call EndScene(), which is required before exporting.");
     }
 }

--- a/Editor/CheckSystem/Checks/LayersChecker.cs
+++ b/Editor/CheckSystem/Checks/LayersChecker.cs
@@ -1,0 +1,41 @@
+using ImmerzaSDK.Manager.Editor;
+using System.Collections.Generic;
+using System.Runtime.Remoting.Contexts;
+using UnityEditor;
+using UnityEngine;
+
+[CheckableAttribute(displayName: "Validate Layers Check")]
+public class LayersChecker : ICheckable
+{
+    private const int NumReservedLayers = 16;
+    private readonly Dictionary<int, string> PrivateLayers = new()
+    {
+        { 0, "Default" },
+        { 1, "TransparentFX" },
+        { 2, "Ignore Raycast" },
+        { 4, "Water" },
+        { 5, "UI" }
+    };
+
+    public void RunCheck(CheckContext context   )
+    {
+        SerializedObject serializedObject = new SerializedObject(AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/TagManager.asset")[0]);
+        SerializedProperty serializedProperty = serializedObject.FindProperty("layers");
+        
+        string name;
+        for (int i = 0; i < NumReservedLayers; ++i)
+        {
+            name = serializedProperty.GetArrayElementAtIndex(i).stringValue;
+            if (name != PrivateLayers.GetValueOrDefault(i, string.Empty))
+            {
+                context.AddError($"Layer {i} ({name}) is a private layer and cannot be used by the scenario");
+            }
+        }
+
+        name = serializedProperty.GetArrayElementAtIndex(31).stringValue;
+        if (!string.IsNullOrEmpty(name))
+        {
+            context.AddError("Layer 31 cannot be used as it is used within Unity Editor for special purpose");
+        }
+    }
+}

--- a/Editor/CheckSystem/Checks/LayersChecker.cs.meta
+++ b/Editor/CheckSystem/Checks/LayersChecker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8d13a969c6e49f94e9bbace5983b5e62

--- a/Editor/CheckSystem/Checks/LuaBindingsChecker.cs
+++ b/Editor/CheckSystem/Checks/LuaBindingsChecker.cs
@@ -6,14 +6,14 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
+[CheckableAttribute(displayName: "Lua Bindings Check")]
 public class LuaBindingsChecker : ICheckable
 {
-    List<CheckResult> ICheckable.RunCheck()
+    public void RunCheck(CheckContext context)
     {
         HashSet<string> luaBindings = CheckUtil.GetAllLuaBindingNames();
         List<LuaAsset> luaScripts = CheckUtil.GetLuaAssets();
-        List<CheckResult> illegalBindings = new();
-
+        
         Regex typeRegex = new(@"\bCS\.[A-Za-z_][A-Za-z0-9_.]*\b", RegexOptions.Compiled);
 
         foreach (LuaAsset script in luaScripts)
@@ -26,31 +26,9 @@ public class LuaBindingsChecker : ICheckable
 
                 if (!luaBindings.Contains(foundType))
                 {
-                    illegalBindings.Add(new CheckResult()
-                    {
-                        Type = ResultType.Warning,
-                        Message = $"Unknown type found in {script.name}: {foundType}",
-                        ContextObject = script
-                    });
+                    context.AddWarning($"Unknown type found in {script.name}: {foundType}", script);
                 }
             }
-        }
-
-        if (illegalBindings.Count == 0)
-        {
-            return new List<CheckResult>
-            {
-                new()
-                {
-                    Type = ResultType.Success,
-                    Message = "LuaBindingsChecker succeeded.",
-                    ContextObject = null
-                }
-            };
-        }
-        else
-        {
-            return illegalBindings;
         }
     }
 }

--- a/Editor/CheckSystem/Checks/LuaManagerChecker.cs
+++ b/Editor/CheckSystem/Checks/LuaManagerChecker.cs
@@ -4,59 +4,24 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
+[CheckableAttribute(displayName: "Lua Manager Check")]
 public class LuaManagerChecker : ICheckable
 {
-    List<CheckResult> ICheckable.RunCheck()
+    public void RunCheck(CheckContext context)
     {
         ImmerzaLuaManager[] found = Object.FindObjectsByType<ImmerzaLuaManager>(FindObjectsInactive.Include, FindObjectsSortMode.None);
 
         if (found.Length == 0)
         {
-            return new List<CheckResult> 
-            {
-                new()
-                {
-                    Type = ResultType.Error,
-                    Message = "ImmerzaLuaManager not found inside scene! Add an empty GameObject to your scene and add the component.",
-                    ContextObject = null
-                }
-            };
+            context.AddError("ImmerzaLuaManager not found inside scene! Add an empty GameObject to your scene and add the component.");
         }
-
-        if (found.Length > 1)
+        else if (found.Length > 1)
         {
-            return new List<CheckResult>
-            {
-                new()
-                {
-                    Type = ResultType.Warning,
-                    Message = $"Multiple ImmerzaLuaManagers found inside scene! Remove the duplicates: {string.Join(", ", found.Select(obj => obj.name))}",
-                    ContextObject = null
-                }
-            };
+            context.AddWarning($"Multiple ImmerzaLuaManagers found inside scene! Remove the duplicates: {string.Join(", ", found.Select(obj => obj.name))}");
         }
-
-        if (!found[0].isActiveAndEnabled)
+        else if (!found[0].isActiveAndEnabled)
         {
-            return new List<CheckResult> 
-            {
-                new()
-                {
-                    Type = ResultType.Warning,
-                    Message = $"ImmerzaLuaManager inactive, consider reactivating it before exporting.",
-                    ContextObject = found[0]
-                }
-            };
+            context.AddWarning($"ImmerzaLuaManager inactive, consider reactivating it before exporting.", found[0]);
         }
-
-        return new List<CheckResult> 
-        {
-            new()
-            {
-                Type = ResultType.Success,
-                Message = "ImmerzaLuaManager check succeeded.",
-                ContextObject = found[0]
-            }
-        };
     }
 }

--- a/Editor/CheckSystem/Checks/OnPauseRequestedChecker.cs
+++ b/Editor/CheckSystem/Checks/OnPauseRequestedChecker.cs
@@ -5,9 +5,10 @@ using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
 
+[CheckableAttribute(displayName: "LUA OnPauseRequested Check")]
 public class OnPauseRequestedChecker : ICheckable
 {
-    List<CheckResult> ICheckable.RunCheck()
+    public void RunCheck(CheckContext context)
     {
         List<LuaAsset> scripts = CheckUtil.GetLuaAssets();
 
@@ -17,24 +18,10 @@ public class OnPauseRequestedChecker : ICheckable
         {
             if (regex.IsMatch(script.content))
             {
-                return new List<CheckResult> {
-                    new()
-                    {
-                        Type = ResultType.Success,
-                        Message = "OnPauseRequested check succeeded",
-                        ContextObject = null
-                    }
-                };
+                return;
             }
         }
 
-        return new List<CheckResult> {
-            new()
-            {
-                Type = ResultType.Error,
-                Message = "None of the Lua scripts implement OnPauseRequested, which is required before exporting.",
-                ContextObject = null
-            }
-        };
+        context.AddError("None of the Lua scripts implement OnPauseRequested, which is required before exporting.");
     }
 }

--- a/Editor/CheckSystem/Checks/XRUIInputChecker.cs
+++ b/Editor/CheckSystem/Checks/XRUIInputChecker.cs
@@ -8,74 +8,40 @@ using UnityEngine.XR.Interaction.Toolkit;
 using UnityEngine.XR.Interaction.Toolkit.Interactors;
 using static UnityEditor.Experimental.GraphView.GraphView;
 
+[CheckableAttribute(displayName: "XR UI Input Check")]
 public class XRUIInputChecker : ICheckable
 {
-    List<CheckResult> ICheckable.RunCheck()
+    public void RunCheck(CheckContext context)
     {
         NearFarInteractor[] found = Object.FindObjectsByType<NearFarInteractor>(FindObjectsInactive.Include, FindObjectsSortMode.None);
 
         if (found.Length == 0)
         {
-            return new List<CheckResult>
-            {
-                new()
-                {
-                    Type = ResultType.Error,
-                    Message = "No NearFarInteractors found! Scene needs atleast two set to the 'UI' layer.",
-                    ContextObject = null
-                }
-            };
+            context.AddError("No NearFarInteractors found! Scene needs atleast two set to the 'UI' layer.");
         }
-
-        if (found.Length == 1)
+        else if (found.Length == 1)
         {
             if ((found[0].interactionLayers.value & (1 << InteractionLayerMask.GetMask("UI"))) == 0)
             {
-                return new List<CheckResult>
-                {
-                    new()
-                    {
-                        Type = ResultType.Error,
-                        Message = "Not one NearFarInteractor with the 'UI' interaction layer has been found! Scene needs atleast two set to the 'UI' layer.",
-                        ContextObject = null
-                    }
-                };
+                context.AddError("Not one NearFarInteractor with the 'UI' interaction layer has been found! Scene needs atleast two set to the 'UI' layer.");
             }
-        }
-
-        int foundInteractors = 0;
-
-        foreach (NearFarInteractor interactor in found)
-        {
-            if ((interactor.interactionLayers.value & (1 << InteractionLayerMask.GetMask("UI"))) != 0)
-            {
-                foundInteractors++;
-            }
-        }
-
-        if (foundInteractors >= 2)
-        {
-            return new List<CheckResult>
-            {
-                new()
-                {
-                    Type = ResultType.Success,
-                    Message = "XR UI Input check succeeded.",
-                    ContextObject = null
-                }
-            };
         }
         else
         {
-            return new List<CheckResult>
+            int foundInteractors = 0;
+
+            foreach (NearFarInteractor interactor in found)
             {
-                new()
+                if ((interactor.interactionLayers.value & (1 << InteractionLayerMask.GetMask("UI"))) != 0)
                 {
-                    Type = ResultType.Error,
-                    Message = "Only one NearFarInteractor with the 'UI' interaction layer has been found! Scene needs atleast two set to the 'UI' layer.",
-                    ContextObject = found[0]
+                    foundInteractors++;
                 }
-            };
+            }
+
+            if (foundInteractors < 2)
+            {
+                context.AddError("Only one NearFarInteractor with the 'UI' interaction layer has been found! Scene needs atleast two set to the 'UI' layer.", found[0]);
+            }
         }
     }
 }

--- a/Editor/CheckSystem/ICheckable.cs
+++ b/Editor/CheckSystem/ICheckable.cs
@@ -1,9 +1,22 @@
+using JetBrains.Annotations;
+using System;
 using System.Collections.Generic;
 
 namespace ImmerzaSDK.Manager.Editor
 {
     internal interface ICheckable
     {
-        List<CheckResult> RunCheck();
+        void RunCheck(CheckContext context);
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    internal class CheckableAttribute : Attribute
+    {
+        public CheckableAttribute(string displayName)
+        {
+            DisplayName = displayName;
+        }
+
+        public string DisplayName { get; private set; }
     }
 }

--- a/Editor/SDKManagerWindow.cs
+++ b/Editor/SDKManagerWindow.cs
@@ -139,7 +139,7 @@ namespace ImmerzaSDK.Manager.Editor
             VisualElement mainPageRoot = rootVisualElement.Q<VisualElement>("MainPage");
 
             _errorBox = mainPageRoot.Q<GroupBox>("ErrorBox");
-            _warningBox = mainPageRoot.Q<GroupBox>("WarningBox");
+            _warningBox = mainPageRoot.Q<GroupBox>("WarningsBox");
             _warningCountLabel = mainPageRoot.Q<Label>("WarningsCount");
             _errorCountLabel = mainPageRoot.Q<Label>("ErrorsCount");
 
@@ -164,6 +164,7 @@ namespace ImmerzaSDK.Manager.Editor
 
 #if IMMERZA_SDK_INSTALLED
             PreflightCheckManager.OnLogCheck += HandleNewCheckResults;
+            PreflightCheckManager.OnBeforeRunChecks += OnBeforeRunChecks;
             DispatchChecks();
 #endif
 
@@ -477,24 +478,31 @@ namespace ImmerzaSDK.Manager.Editor
             PreflightCheckManager.RunChecks();
         }
 
-        private void HandleNewCheckResults(List<CheckResult> checkResults)
+        private void HandleNewCheckResults(ResultType type, string message)
         {
-            foreach (CheckResult res in checkResults)
+            if (type == ResultType.Error)
             {
-                if (res.Type == ResultType.Error)
-                {
-                    _errorCountLabel.text = Convert.ToString(++_errorCount);
-                    Label newMsg = new(res.Message);
-                    newMsg.AddToClassList("label-wrap");
-                    _errorBox.Add(newMsg);
-                }
-                else if (res.Type == ResultType.Warning)
-                {
-                    _warningCountLabel.text = Convert.ToString(++_warningCount);
-                    _warningBox.Add(new Label(res.Message));
-                }
+                _errorCountLabel.text = Convert.ToString(++_errorCount);
+                Label newMsg = new(message);
+                newMsg.AddToClassList("label-wrap");
+                _errorBox.Add(newMsg);
+            }
+            else if (type == ResultType.Warning)
+            {
+                _warningCountLabel.text = Convert.ToString(++_warningCount);
+                _warningBox.Add(new Label(message));
             }
         }
-        #endif
+
+        private void OnBeforeRunChecks()
+        {
+            _warningCount = 0;
+            _errorCount = 0;
+            _errorBox.Clear();
+            _warningBox.Clear();
+            _warningCountLabel.text = "0";
+            _errorCountLabel.text = "0";
+        }
+#endif
     }
 }


### PR DESCRIPTION
…ftermath

* add new event 'OnBeforerunChecks' to let sdk manager window clear the view in case the check where ran by another instance while the window was kept open
* small cleanup of checks api, so the check code is less noisy. mostly collect results in a context and adding some syntactic sugar api
* add new attribute that exposes display name of a check to the runner
* add new check for layers integrity