### PR TITLE
Fix Format Exception: String was not recognized as a valid DateTime.

### DIFF
--- a/Editor/SDKManagerWindow.Update.cs
+++ b/Editor/SDKManagerWindow.Update.cs
@@ -153,7 +153,8 @@ namespace ImmerzaSDK.Manager.Editor
                 }
 
                 JToken versionInfoLastUpdate = firstEntry["resource"]["meta"]["lastUpdated"];
-                DateTimeOffset dateTimeOffset = DateTimeOffset.Parse(versionInfoLastUpdate.Value<string>() ?? string.Empty);
+                string dateString = versionInfoLastUpdate.Value<string>() ?? string.Empty;
+                DateTimeOffset dateTimeOffset = DateTimeOffset.Parse(dateString, CultureInfo.InvariantCulture);
                 releaseInfo = new ReleaseInfo(version, fileId, changelog, dateTimeOffset.ToUnixTimeSeconds());
 
             }


### PR DESCRIPTION
The SDK Manager was throwing FormatException errors on Windows systems configured with non-English locales. The issue occurred because DateTimeOffset.Parse() uses the system's current culture settings to interpret date strings, causing parsing failures when the API response format doesn't match the expected locale-specific forma